### PR TITLE
Bump the default version of Kubernetes for GKE cluster module

### DIFF
--- a/common/infrastructure/variables.tf
+++ b/common/infrastructure/variables.tf
@@ -95,7 +95,7 @@ variable "cluster_labels" {
 
 variable "kubernetes_version" {
   type    = string
-  default = "1.30"
+  default = "1.31"
 }
 
 variable "release_channel" {


### PR DESCRIPTION
Update the kubernetes version for the GKE cluster module since the current version 1.30 is no longer supported (https://cloud.google.com/kubernetes-engine/docs/release-notes#2025-r42-version-updates).